### PR TITLE
Fix user fields

### DIFF
--- a/code/controllers/FacebookConnectAuthCallback.php
+++ b/code/controllers/FacebookConnectAuthCallback.php
@@ -10,7 +10,7 @@ use Facebook\FacebookRequestException;
  */
 class FacebookConnectAuthCallback extends Controller
 {
-    
+
     private static $allowed_actions = array(
         'connect'
     );
@@ -31,7 +31,7 @@ class FacebookConnectAuthCallback extends Controller
         if ($session) {
             $token = $session->getAccessToken();
 
-            // get a long lived token by default. Access token is saved in 
+            // get a long lived token by default. Access token is saved in
             // session.
             try {
                 $long = $token->extend($appId, $secret);
@@ -44,32 +44,32 @@ class FacebookConnectAuthCallback extends Controller
             } catch (Exception $e) {
                 $accessTokenValue = (string) $token;
             }
-            
+
             try {
                 Session::set(
                     FacebookControllerExtension::FACEBOOK_ACCESS_TOKEN,
                     $accessTokenValue
                 );
 
-                
+
                 $fields = Config::inst()->get(
                     'FacebookControllerExtension', 'facebook_fields'
                 );
 
                 $user = (new FacebookRequest(
-                    $session, 'GET', '/me', $fields
+                    $session, 'GET', '/me', array('fields' => implode(',', $fields))
                 ))->execute()->getGraphObject(GraphUser::className());
 
                 if (!$member = Member::currentUser()) {
-                    // member is not currently logged into SilverStripe. Look up 
+                    // member is not currently logged into SilverStripe. Look up
                     // for a member with the UID which matches first.
                     $member = Member::get()->filter(array(
                         "FacebookUID" => $user->getId()
                     ))->first();
 
                     if (!$member) {
-                        // see if we have a match based on email. From a 
-                        // security point of view, users have to confirm their 
+                        // see if we have a match based on email. From a
+                        // security point of view, users have to confirm their
                         // email address in facebook so doing a match up is fine
                         $email = $user->getProperty('email');
 
@@ -84,7 +84,7 @@ class FacebookConnectAuthCallback extends Controller
                         $member = Injector::inst()->create('Member');
                     }
                 }
-                
+
                 $member->syncFacebookDetails($user);
                 $member->logIn();
 


### PR DESCRIPTION
FacebookRequest excepts the fourth parameter to be an associative array with one of the keys being `fields`. The value must be comma separated list of fields.

Not sure if (and at which point) this has been changed but #22 seems to be the one that first introduced `['fields' => 'comma,separated']`. Then #23 broke that. So this is to fix #23 and to keep the fields configurable.