### PR TITLE
Fix error ”performReadonlyTransformation() on null”

### DIFF
--- a/code/extensions/FacebookMemberExtension.php
+++ b/code/extensions/FacebookMemberExtension.php
@@ -29,9 +29,11 @@ class FacebookMemberExtension extends DataExtension
     
     public function updateCMSFields(FieldList $fields)
     {
-        $fields->makeFieldReadonly('FacebookUID');
-        $fields->makeFieldReadonly('FacebookLink');
-        $fields->makeFieldReadonly('FacebookTimezone');
+        if($fields->getField('FacebookUID')){
+            $fields->makeFieldReadonly('FacebookUID');
+            $fields->makeFieldReadonly('FacebookLink');
+            $fields->makeFieldReadonly('FacebookTimezone');
+        }
     }
     
     /**


### PR DESCRIPTION
Fix for Members that dont have any values for the Facebook specific member fields